### PR TITLE
[RFR] Added Ansible Galaxy Playbook updating with requirements.yml

### DIFF
--- a/ansible_galaxy_role_users.yaml
+++ b/ansible_galaxy_role_users.yaml
@@ -1,0 +1,5 @@
+---
+- hosts: all
+  connection: local
+  roles:
+  - singleplatform-eng.users

--- a/roles/requirements.yml
+++ b/roles/requirements.yml
@@ -1,2 +1,3 @@
 ---
-- src: syncrou.manageiq-vmdb
+# from galaxy
+- src: singleplatform-eng.users


### PR DESCRIPTION
Updated `roles/requirements.yml` with Ansible Galaxy role information.
The playbook `ansible_galaxy_role_users.yaml` will fetch `singleplatform-eng.users` role from Ansible Galaxy.
Playbooks required for PR #9194